### PR TITLE
Create and launch applet on AWT EventQueue thread

### DIFF
--- a/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
+++ b/minecraft/src/main/java/net/fabricmc/loader/impl/game/minecraft/applet/AppletMain.java
@@ -18,8 +18,11 @@ package net.fabricmc.loader.impl.game.minecraft.applet;
 
 import java.io.File;
 
-public final class AppletMain {
-	private AppletMain() { }
+public final class AppletMain implements Runnable{
+        final String[] args;
+	private AppletMain(String[] args) { 
+                this.args = args;
+        }
 
 	public static File hookGameDir(File file) {
 		File proposed = AppletLauncher.gameDir;
@@ -32,7 +35,12 @@ public final class AppletMain {
 	}
 
 	public static void main(String[] args) {
-		AppletFrame me = new AppletFrame("Minecraft", null);
-		me.launch(args);
+                java.awt.EventQueue.invokeLater(new AppletMain(args));
 	}
+
+        @Override
+        public void run() {
+                AppletFrame me = new AppletFrame("Minecraft", null);
+		me.launch(args);
+        }
 }


### PR DESCRIPTION
This fixes sometimes occuring race conditions and changes the current behavior to what's suggested by the [AWT/Swing documentation](https://docs.oracle.com/javase/tutorial/uiswing/concurrency/initial.html)